### PR TITLE
managed start session when target instance is private

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -180,13 +180,12 @@ func setTarget() error {
 		viper.Set("target", target)
 		viper.Set("domain", domain)
 	} else {
+		viper.Set("target", target)
 		domain, err = findDomainByInstanceId(region, target)
 		if err != nil {
 			return err
 		}
-		if domain == "" {
-			return fmt.Errorf("[err] don't exist running instances \n")
-		}
+
 		viper.Set("domain", domain)
 	}
 
@@ -238,6 +237,11 @@ func setSSHWithCLI() error {
 	if err := setTarget(); err != nil {
 		return err
 	}
+	//verify that domain has been set
+	if viper.Get("domain") == nil {
+		return fmt.Errorf("[err] don't exist running instances \n")
+	}
+
 	if err := setUser(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi, when I try to start a session declaring a private instance in this way: 
```
gossm start -r eu-west-1 -t i-0123q45q6q7890
```
I received this error: `[err] don't exist running instances`. I noticed this happens because the `setTarget` function looking for the public domain of the instance but does not exists. My solution did not raise the error inside the `setTarget` function but inside the `setSSHWithCLI`. What do you think? 

PS: if is ok for you think should be managed also for the `setMultiTarget` function