### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:alpine as builder
+WORKDIR /build
+ADD . .
+RUN CGO_ENABLED=0 go build -ldflags='-w -s -extldflags "-static"' -a -o /build/gossm .
+
+FROM scratch 
+COPY --from=builder /build/ /go/bin/
+CMD [ "/go/bin/gossm" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ ADD . .
 RUN CGO_ENABLED=0 go build -ldflags='-w -s -extldflags "-static"' -a -o /build/gossm .
 
 FROM scratch 
+ENV PATH /go/bin
 COPY --from=builder /build/ /go/bin/
 CMD [ "/go/bin/gossm" ]


### PR DESCRIPTION
This Dockerfile compiles gossm as a staticly linked binary. To make it work you'll need to mount your AWS credentials directory in the Docker container, or change gossm to work with environment variables which imo is the preferred way.

Let me know if you see any improvements to this.