### PR TITLE
Fix for Environment variables not being used

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,7 +185,14 @@ func makeSession(credFile, profile string) (*session.Session, string, error) {
 		return sess, profile, err
 	}
 
-	// default cred
+	// default creds
+	envPresent := os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != ""
+	if envPresent {
+		sess, err := session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		})
+		return sess, "env", err
+	}
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Profile:                 profile,
 		SharedConfigState:       session.SharedConfigEnable,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -28,4 +28,11 @@ func TestMakeSession(t *testing.T) {
 	_, p, err = makeSession("", "")
 	assert.NoError(err)
 	assert.Equal("test-account", p)
+	os.Setenv("AWS_PROFILE", "")
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "ABCDEFGHIJKLMNOP")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "abcdef123456")
+	_, p, err = makeSession("", "")
+	assert.NoError(err)
+	assert.Equal("env", p)
 }


### PR DESCRIPTION
Fix for https://github.com/gjbae1212/gossm/issues/17

Test output
```
=== RUN   TestCmd
--- PASS: TestCmd (0.00s)
=== RUN   TestScpInit
--- PASS: TestScpInit (0.00s)
=== RUN   TestScp
--- PASS: TestScp (0.00s)
=== RUN   TestSessionInit
--- PASS: TestSessionInit (0.00s)
=== RUN   TestSshInit
--- PASS: TestSshInit (0.00s)
=== RUN   TestCallProcess
hello
--- PASS: TestCallProcess (0.00s)
=== RUN   TestPrintReady
[hello] profile: , region: ap-northeast-2, target: 
--- PASS: TestPrintReady (0.00s)
=== RUN   TestFindInstanceId
--- PASS: TestFindInstanceId (0.84s)
=== RUN   TestExecute
gossm is interactive CLI tool that you select server in AWS and then could connect or send files your AWS server using start-session, ssh, scp in AWS Systems Manger Session Manager.

Usage:
  gossm [command]

Available Commands:
  cmd         Exec `run command` under AWS SSM with interactive CLI
  help        Help about any command
  scp         Exec `scp` under AWS SSM with interactive CLI
  ssh         Exec `ssh` under AWS SSM with interactive CLI
  start       Exec `start-session` under AWS SSM with interactive CLI

Flags:
  -c, --cred string      aws credentials file (default is $HOME/.aws/.credentials)
  -h, --help             help for gossm
  -p, --profile string   
                         [optional] if you are having multiple aws profiles, it is one of profiles (default is AWS_PROFILE environment variable or default)
  -r, --region string    [optional] it is region in AWS that would like to do something
  -t, --target string    [optional] it is instanceId of server in AWS that would like to something
  -v, --version          version for gossm

Use "gossm [command] --help" for more information about a command.
--- PASS: TestExecute (0.00s)
=== RUN   TestMakeSession
--- PASS: TestMakeSession (0.01s)
PASS
ok      github.com/gjbae1212/gossm/cmd  1.920s
```

Added check to see if `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables are set. If they are then we need to create our session without the `Profile` value, otherwise it will override the environment variables. This behaviour is documented [here](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/)
> The Environment variables for credentials will have precedence over shared config even if SharedConfig is enabled. To override this behaviour, and use shared config credentials instead specify the session.Options.Profile

Will not work if only one of the variables is set. Assume role configs will need to provide the `AWS_SESSION_TOKEN` environment variable, but left the check for this since the SDK will look for this environment variable itself.