### PR TITLE
Allow to use `--target` flag with Private Instances

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -194,9 +194,6 @@ func setMultiTarget(c *Credential, s *Executor) error {
 		if err != nil {
 			return err
 		}
-		if domain == "" {
-			return fmt.Errorf("[err] don't exist running instances \n")
-		}
 
 		s.multiTarget = []string{s.target}
 		s.multiDomain = []string{domain}
@@ -450,7 +447,7 @@ func findDomainByInstanceId(sess *session.Session, region string, instanceId str
 			}
 		}
 	}
-	return "", nil
+	return "", fmt.Errorf("[err] instanceId not found")
 }
 
 // Call command

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -447,7 +447,7 @@ func findDomainByInstanceId(sess *session.Session, region string, instanceId str
 			}
 		}
 	}
-	return "", fmt.Errorf("[err] instanceId not found")
+	return "", fmt.Errorf("instanceId not found")
 }
 
 // Call command


### PR DESCRIPTION
Using `--target` flag only works with instances with public DNS records. In the `setMultiTarget()` function there is an if condition that checks for the `domain` of the instance and fails if it doesn't exist; Private Instances does not have a domain, however, you can still connect to them using their instance-id.

I removed this check and modified the `findDomainByInstanceId()` function to return a descriptive error if the instance was not found by its ID to accommodate for the removed condition check.

Now I can use `--target` for Private Instances, and I can happily use SSM in my CI/CD <3