### PR TITLE
Fix bug where instance only has either public or private ip.

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -505,7 +505,7 @@ func findInstanceIdByIp(sess *session.Session, region, ip string) (string, error
 				return *inst.InstanceId, nil
 			}
 			if inst.PrivateIpAddress != nil && ip == *inst.PublicIpAddress {
-				return *inst.PublicIpAddress, nil
+				return *inst.InstanceId, nil
 			}
 		}
 	}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -501,11 +501,11 @@ func findInstanceIdByIp(sess *session.Session, region, ip string) (string, error
 	}
 	for _, rv := range output.Reservations {
 		for _, inst := range rv.Instances {
-			if inst.PublicIpAddress == nil || inst.PrivateIpAddress == nil {
-				continue
-			}
-			if ip == *inst.PublicIpAddress || ip == *inst.PrivateIpAddress {
+			if inst.PublicIpAddress != nil && ip == *inst.PublicIpAddress{
 				return *inst.InstanceId, nil
+			}
+			if inst.PrivateIpAddress != nil && ip == *inst.PublicIpAddress {
+				return *inst.PublicIpAddress, nil
 			}
 		}
 	}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -504,7 +504,7 @@ func findInstanceIdByIp(sess *session.Session, region, ip string) (string, error
 			if inst.PublicIpAddress != nil && ip == *inst.PublicIpAddress{
 				return *inst.InstanceId, nil
 			}
-			if inst.PrivateIpAddress != nil && ip == *inst.PublicIpAddress {
+			if inst.PrivateIpAddress != nil && ip == *inst.PrivateIpAddress {
 				return *inst.InstanceId, nil
 			}
 		}


### PR DESCRIPTION
This pull request fixes a bug where, if an EC2 instance only have a private or a public IP, it gets ignored.

```golang
if inst.PublicIpAddress == nil || inst.PrivateIpAddress == nil {
   continue
}
```

Since it's an OR, it means it only accepts instance with both a public and a private IP.

My pull request fixes this bug by looking at each IP individually