### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - init: go get && go build ./... && go test ./...
+    command: go run .
+
+vscode:
+  extensions:
+    - golang.go


### PR DESCRIPTION

This adds a [Gitpod](https://gitpod.io/) configuration to help get started with Gitpod to make it easier for new engineers to work on the project.