### PR TITLE
Format selection list as a table

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,7 +40,7 @@ var (
 					panicRed(err)
 				}
 				for _, t := range table {
-					if t.Name == argTarget {
+					if t.InstanceId == argTarget {
 						targets = append(targets, t)
 						break
 					}
@@ -56,7 +56,7 @@ var (
 
 			var targetName string
 			for _, t := range targets {
-				targetName += " " + t.Name + " "
+				targetName += " " + t.InstanceId + " "
 			}
 
 			internal.PrintReady(exec, _credential.awsConfig.Region, targetName)

--- a/cmd/fwd.go
+++ b/cmd/fwd.go
@@ -36,7 +36,7 @@ var (
 					panicRed(err)
 				}
 				for _, t := range table {
-					if t.Name == argTarget {
+					if t.InstanceId == argTarget {
 						target = t
 						break
 					}
@@ -66,7 +66,7 @@ var (
 					localPort = remotePort
 				}
 			}
-			internal.PrintReady(fmt.Sprintf("start-port-forwarding %s -> %s", localPort, remotePort), _credential.awsConfig.Region, target.Name)
+			internal.PrintReady(fmt.Sprintf("start-port-forwarding %s -> %s", localPort, remotePort), _credential.awsConfig.Region, target.InstanceId)
 
 			docName := "AWS-StartPortForwardingSession" // https://us-east-1.console.aws.amazon.com/systems-manager/documents/AWS-StartPortForwardingSession/description?region=us-east-1
 			input := &ssm.StartSessionInput{
@@ -75,7 +75,7 @@ var (
 					"portNumber":      []string{remotePort},
 					"localPortNumber": []string{localPort},
 				},
-				Target: aws.String(target.Name),
+				Target: aws.String(target.InstanceId),
 			}
 
 			// start session

--- a/cmd/fwdrem.go
+++ b/cmd/fwdrem.go
@@ -37,7 +37,7 @@ var (
 					panicRed(err)
 				}
 				for _, t := range table {
-					if t.Name == argTarget {
+					if t.InstanceId == argTarget {
 						target = t
 						break
 					}
@@ -79,7 +79,7 @@ var (
 				host = argHost
 			}
 
-			internal.PrintReady(fmt.Sprintf("start-port-forwarding %s -> %s", localPort, remotePort), _credential.awsConfig.Region, target.Name)
+			internal.PrintReady(fmt.Sprintf("start-port-forwarding %s -> %s", localPort, remotePort), _credential.awsConfig.Region, target.InstanceId)
 
 			docName := "AWS-StartPortForwardingSessionToRemoteHost" // https://us-east-1.console.aws.amazon.com/systems-manager/documents/AWS-StartPortForwardingSession/description?region=us-east-1
 
@@ -90,7 +90,7 @@ var (
 					"localPortNumber": []string{localPort},
 					"host":            []string{host},
 				},
-				Target: aws.String(target.Name),
+				Target: aws.String(target.InstanceId),
 			}
 
 			// start session

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -33,7 +33,7 @@ var (
 					panicRed(err)
 				}
 				for _, t := range table {
-					if t.Name == argTarget {
+					if t.InstanceId == argTarget {
 						target = t
 						break
 					}
@@ -45,9 +45,9 @@ var (
 					panicRed(err)
 				}
 			}
-			internal.PrintReady("start-session", _credential.awsConfig.Region, target.Name)
+			internal.PrintReady("start-session", _credential.awsConfig.Region, target.InstanceId)
 
-			input := &ssm.StartSessionInput{Target: aws.String(target.Name)}
+			input := &ssm.StartSessionInput{Target: aws.String(target.InstanceId)}
 			session, err := internal.CreateStartSession(ctx, *_credential.awsConfig, input)
 			if err != nil {
 				panicRed(err)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -36,7 +36,7 @@ var (
 				if err != nil {
 					panicRed(err)
 				}
-				targetName = target.Name
+				targetName = target.InstanceId
 
 				sshUser, err := internal.AskUser()
 				if err != nil {

--- a/internal/ssm.go
+++ b/internal/ssm.go
@@ -43,7 +43,7 @@ var (
 
 type (
 	Target struct {
-		Name          string
+		InstanceId    string
 		PublicDomain  string
 		PrivateDomain string
 	}
@@ -222,7 +222,7 @@ func FindInstances(ctx context.Context, cfg aws.Config) (map[string]*Target, err
 						}
 					}
 					table[fmt.Sprintf("%s\t(%s)", name, *inst.InstanceId)] = &Target{
-						Name:          aws.ToString(inst.InstanceId),
+						InstanceId:    aws.ToString(inst.InstanceId),
 						PublicDomain:  aws.ToString(inst.PublicDnsName),
 						PrivateDomain: aws.ToString(inst.PrivateDnsName),
 					}
@@ -468,7 +468,7 @@ func SendCommand(ctx context.Context, cfg aws.Config, targets []*Target, command
 
 	var ids []string
 	for _, t := range targets {
-		ids = append(ids, t.Name)
+		ids = append(ids, t.InstanceId)
 	}
 
 	input := &ssm.SendCommandInput{


### PR DESCRIPTION
This aligns all the instance IDs.

Also, since they are now aligned, I removed the surrounding parenthesis.

I also made the `Target` properties a little bit more clear. I'm happy to revert that change and move the `Name` tag out of the target, this just felt easier to understand to me.